### PR TITLE
Enable conventional-commits plugin

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -3,7 +3,8 @@
     "git-tag",
     "all-contributors",
     "first-time-contributor",
-    "released"
+    "released",
+    "conventional-commits"
   ],
   "owner": "arclamp",
   "repo": "auto-test",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,41 @@ name: Release
 on: [push]
 
 jobs:
-  release:
+  monitor:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prepare repository
+        run: git fetch --unshallow --tags
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install node-based plugins
+        run: |
+          sudo npm install -g @auto-it/conventional-commits
+
+      - name: Download latest auto
+        run: |
+          auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"
+          wget -O- "$auto_download_url" | gunzip > ~/auto
+          chmod a+x ~/auto
+
+      - name: Calculate version updates
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ~/auto version
+          ~/auto changelog -d
+          ~/auto release -d
+          ~/auto shipit -d
+
+  release:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ~/auto shipit -vv
+          ~/auto shipit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,28 @@ jobs:
           wget -O- "$auto_download_url" | gunzip > ~/auto
           chmod a+x ~/auto
 
-      - name: Calculate version updates
+      - name: Calculate new version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ~/auto version
+
+      - name: Dry run changelog generation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           ~/auto changelog -d
+
+      - name: Dry run release process
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           ~/auto release -d
+
+      - name: Dry run automated release loop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           ~/auto shipit -d
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,15 @@ jobs:
       - name: Prepare repository
         run: git fetch --unshallow --tags
 
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install node-based plugins
+        run: |
+          sudo npm install -g @auto-it/conventional-commits
+
       - name: Download latest auto
         run: |
           auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"


### PR DESCRIPTION
This allows for using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to control the versioning procedure.